### PR TITLE
Update iOS to Airship SDK 20, fix turbo module

### DIFF
--- a/ios/RtnGimbalAirshipAdapter.h
+++ b/ios/RtnGimbalAirshipAdapter.h
@@ -2,16 +2,7 @@
 #import "VisitEvent.h"
 #import "GimbalService.h"
 #import "AdapterEventEmitter.h"
-
-#ifdef RCT_NEW_ARCH_ENABLED
 #import "RNRtnGimbalAirshipAdapterSpec.h"
 
-@interface RtnGimbalAirshipAdapter : NSObject <NativeGimbalAirshipAdapterSpec,GMBLPlaceManagerDelegate>
-#else
-#import <React/RCTBridgeModule.h>
-#import <Gimbal/Gimbal.h>
-
-@interface RtnGimbalAirshipAdapter : RCTEventEmitter <RCTBridgeModule, GMBLPlaceManagerDelegate>
-#endif
-
+@interface RtnGimbalAirshipAdapter : NSObject <NativeGimbalAirshipAdapterModuleSpec, GMBLPlaceManagerDelegate>
 @end

--- a/ios/RtnGimbalAirshipAdapter.mm
+++ b/ios/RtnGimbalAirshipAdapter.mm
@@ -43,20 +43,20 @@ RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
     [[AdapterEventEmitter shared] addListener:eventName];
 }
 
-RCT_EXPORT_METHOD(removeListeners:(NSInteger)count) {
+RCT_EXPORT_METHOD(removeListeners:(double)count) {
     [[AdapterEventEmitter shared] removeListeners:count];
 }
 
-RCT_EXPORT_METHOD(setApiKey:(NSString *)apiKey) {
-    
+RCT_REMAP_METHOD(setGimbalApiKey,
+                 setGimbalApiKey:(NSString *)gimbalApiKey) {
+
 }
 
 RCT_REMAP_METHOD(start,
-                 apiKey:(NSString *)apiKey
-                 start_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-
-    [[GimbalService shared] start:apiKey];
+                 start:(NSString *)gimbalApiKey
+                 resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+    [[GimbalService shared] start:gimbalApiKey];
     resolve(@([[GimbalService shared] isStarted]));
 }
 
@@ -65,28 +65,30 @@ RCT_EXPORT_METHOD(stop) {
 }
 
 RCT_REMAP_METHOD(isStarted,
-                 isStarted_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
+                 isStarted:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
     resolve(@([GimbalService shared].isStarted));
 }
 
 RCT_REMAP_METHOD(getGdprConsentRequirement,
-                 getGdprConsentRequirement_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
+                 getGdprConsentRequirement:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
     GDPRConsentRequirement requirement = [GMBLPrivacyManager gdprConsentRequirement];
     resolve([self convertConsentRequirement:requirement]);
 }
 
 RCT_REMAP_METHOD(getUserConsent,
-                 getUserConsent_type:(NSString *)type
-                 getUserConsent_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
+                 getUserConsent:(NSString *)type
+                 resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
     GMBLConsentState state = [GMBLPrivacyManager userConsentFor:[self convertConsentTypeString:type]];
 
     resolve([self convertConsentState:state]);
 }
 
-RCT_EXPORT_METHOD(setUserConsent:(NSString *)type state:(NSString *)state) {
+RCT_REMAP_METHOD(setUserConsent,
+                 setUserConsent:(NSString *)type
+                 state:(NSString *)state) {
     [GMBLPrivacyManager setUserConsentFor:[self convertConsentTypeString:type]
                                   toState:[self convertConsentStateString:state]];
 }
@@ -168,9 +170,9 @@ RCT_EXPORT_METHOD(setAnalyticsId:(NSString *)id) {
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-    (const facebook::react::ObjCTurboModule::InitParams &)params
+(const facebook::react::ObjCTurboModule::InitParams &)params
 {
-    return std::make_shared<facebook::react::NativeRtnGimbalAirshipAdapterSpecJSI>(params);
+    return std::make_shared<facebook::react::NativeGimbalAirshipAdapterModuleSpecJSI>(params);
 }
 #endif
 

--- a/rtn-gimbal-airship-adapter.podspec
+++ b/rtn-gimbal-airship-adapter.podspec
@@ -11,27 +11,13 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "15.0" }
+  s.platforms    = { :ios => "17.0" }
   s.source       = { :git => "https://github.com/gimbalinc/rtn-gimbal-airship-adapter.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
-  s.dependency "GimbalXCFramework", "~> 2.94.0"
-  s.dependency "GimbalAirshipAdapter", "~> 4.3.0"
+  install_modules_dependencies(s)
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  s.dependency "GimbalXCFramework", "~> 2.94.0"
+  s.dependency "GimbalAirshipAdapter", "~> 5.0.1"
 end

--- a/src/NativeGimbalAirshipAdapterModule.ts
+++ b/src/NativeGimbalAirshipAdapterModule.ts
@@ -1,17 +1,16 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
   addListener(eventName: string): void;
-  removeListeners(count: Int32): void;
+  removeListeners(count: number): void;
   setGimbalApiKey(gimbalApiKey: string): void;
   start(gimbalApiKey: string): Promise<boolean>;
   stop(): void;
   isStarted(): Promise<boolean>;
-  getGdprConsentRequirement(): Promise<Int32>;
-  setUserConsent(consentType: Int32, state: Int32): void;
-  getUserConsent(consentType: Int32): Promise<Int32>;
+  getGdprConsentRequirement(): Promise<string>;
+  setUserConsent(consentType: string, state: string): void;
+  getUserConsent(consentType: string): Promise<string>;
   setShouldTrackCustomEntryEvents(shouldTrack: boolean): void;
   setShouldTrackCustomExitEvents(shouldTrack: boolean): void;
   setShouldTrackRegionEvents(shouldTrack: boolean): void;


### PR DESCRIPTION
This targets Airship SDK 20 which targets the only actively supported RN versions of 82+. 82 dropped support for the old arch so we can drop support for it in this.

If you want to keep these changes for Airship SDK 19 and optionally support turbo, you can you just need to bring back the ifdef in the header and downgrade the gimbal adapter. The native spec was not matching what iOS and Android expected, I assume thats the main issue. 


I only tested that it compiles properly and i was able to call start on new arch. No crashes or issues on my end that I can see, but I did not do any robust testing. 